### PR TITLE
Convert GitHub functionality to async

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=nd,som
+          - --ignore-words-list=nd,som,pullrequest
           - --quiet-level=2
         exclude_types: [csv, json]
   - repo: https://github.com/hadolint/hadolint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 discord
-PyGithub==1.59.1
 pre-commit==2.20.0
+aiohttp==3.8.4

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,6 +4,7 @@ import logging.handlers
 import random
 import traceback
 
+import aiohttp
 import discord
 import gspread_asyncio
 from discord.ext import commands, tasks
@@ -63,6 +64,9 @@ class MILBot(commands.Bot):
     # Roles
     egn4912_role: discord.Role
 
+    # Internal
+    session: aiohttp.ClientSession
+
     def __init__(self):
         super().__init__(
             command_prefix="!",
@@ -76,6 +80,10 @@ class MILBot(commands.Bot):
         if not self.change_status.is_running():
             self.change_status.start()
         await self.fetch_vars()
+
+    async def close(self):
+        await self.session.close()
+        await super().close()
 
     @tasks.loop(hours=1)
     async def change_status(self):
@@ -240,7 +248,8 @@ async def main():
     logger = logging.getLogger()
     logger.addHandler(RichHandler(rich_tracebacks=True))
 
-    async with bot:
+    async with bot, aiohttp.ClientSession() as session:
+        bot.session = session
         await bot.start(token=DISCORD_TOKEN)
 
 

--- a/src/github.py
+++ b/src/github.py
@@ -3,17 +3,24 @@ from __future__ import annotations
 import datetime
 import logging
 import re
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
+import aiohttp
 import discord
-import github
-import requests
 from discord import app_commands
 from discord.ext import commands
-from github import Auth, AuthenticatedUser, Github
-from github.Issue import Issue
 
 from .env import GITHUB_TOKEN
+from .github_types import (
+    Branch,
+    CheckRunsData,
+    CommitSearchResults,
+    Invitation,
+    Issue,
+    OrganizationTeam,
+    Repository,
+    User,
+)
 
 if TYPE_CHECKING:
     from .bot import MILBot
@@ -22,118 +29,197 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class GitHub(commands.Cog):
-    def __init__(self, bot: MILBot):
-        logging.info("Started GitHub initialization...")
+class GitHub:
+    def __init__(self, *, auth_token: str, bot: MILBot):
+        self.auth_token = auth_token
         self.bot = bot
-        self.github = Github(
-            auth=Auth.Token(GITHUB_TOKEN),
-        )
-        self.mil_repo = self.github.get_repo("uf-mil/mil")
-        self.mil_electrical_repos = []
-        all_repos = self.github.get_user().get_repos(sort="pushed")
-        for repo in all_repos:
-            if "uf-mil-electrical" in repo.full_name:
-                self.mil_electrical_repos.append(repo)
-        logging.info("Completed GitHub initialization...")
 
-    def get_commit(self, commit_hash: str) -> discord.Embed | None:
-        logging.info(f"Getting commit info for hash {commit_hash}...")
-        url = f"https://api.github.com/search/commits?q=hash:{commit_hash}+org:uf-mil+org:uf-mil-electrical"
+    async def fetch(
+        self,
+        url: str,
+        *,
+        method: Literal["GET", "POST"] = "GET",
+        extra_headers: dict[str, str] | None = None,
+        data: dict[str, Any] | None = None,
+    ):
+        """
+        Fetches a URL with the given method and headers.
+
+        Raises ClientResponseError if the response status is not 2xx.
+        """
         headers = {
-            "Authorization": f"Bearer {GITHUB_TOKEN}",
+            "Authorization": f"Bearer {self.auth_token}",
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+        async with self.bot.session.request(method, url, data=data) as response:
+            response.raise_for_status()
+            return await response.json()
+
+    async def get_repo(self, repo_name: str) -> Repository:
+        url = f"https://api.github.com/repos/{repo_name}"
+        return await self.fetch(url)
+
+    async def get_issue(self, repo_name: str, issue_number: int) -> Issue:
+        url = f"https://api.github.com/repos/{repo_name}/issues/{issue_number}"
+        return await self.fetch(url)
+
+    async def get_branches_for_commit(self, repo_name: str, hash: str) -> list[Branch]:
+        url = f"https://api.github.com/repos/{repo_name}/commits/{hash}/branches-where-head"
+        return await self.fetch(url)
+
+    async def get_checks(self, repo_name: str, hash: str) -> CheckRunsData:
+        url = f"https://api.github.com/repos/{repo_name}/commits/{hash}/check-runs"
+        extra_headers = {
+            "Accept": "application/vnd.github.v3+json",
+        }
+        return await self.fetch(url, extra_headers=extra_headers)
+
+    async def search_commits(self, hash: str) -> CommitSearchResults:
+        url = f"https://api.github.com/search/commits?q=hash:{hash}+org:uf-mil+org:uf-mil-electrical"
+        headers = {
             "Accept": "application/vnd.github.cloak-preview",  # Required for commit search
         }
-        commit_response = requests.get(url, headers=headers)
+        return await self.fetch(url, extra_headers=headers)
 
-        if commit_response.status_code == 200:
-            commits = commit_response.json()["items"]
-            if commits:
-                commit = commits[0]
-                org_name = commit["repository"]["owner"]["login"]
-                repo_name = commit["repository"]["name"]
-                branches_url = f"https://api.github.com/repos/{org_name}/{repo_name}/commits/{commit_hash}/branches-where-head"
-                branches_response = requests.get(branches_url, headers=headers)
-                branches = [branch["name"] for branch in branches_response.json()]
+    async def get_user(self, username: str) -> User:
+        url = f"https://api.github.com/users/{username}"
+        return await self.fetch(url)
 
-                # URL to get status and checks for the commit
-                checks_url = f"https://api.github.com/repos/{org_name}/{repo_name}/commits/{commit_hash}/check-runs"
-                checks_response = requests.get(
-                    checks_url,
-                    headers={
-                        "Authorization": f"Bearer {GITHUB_TOKEN}",
-                        "Accept": "application/vnd.github.v3+json",
-                    },
-                )
+    async def invite_user_to_org(
+        self,
+        user_id: int,
+        org_name: str,
+        team_id: int | None = None,
+    ) -> Invitation:
+        url = f"https://api.github.com/orgs/{org_name}/invitations"
+        extra_headers = {
+            "Accept": "application/vnd.github.v3+json",
+        }
+        data: dict[str, Any] = {
+            "invitee_id": user_id,
+        }
+        if team_id:
+            data["team_ids"] = [team_id]
+        return await self.fetch(
+            url,
+            method="POST",
+            extra_headers=extra_headers,
+            data=data,
+        )
 
-                embed = discord.Embed(
-                    title=commit["sha"],
-                    color=discord.Color.green(),
-                    url=commit["html_url"],
-                )
-                embed.set_thumbnail(url=commit["repository"]["owner"]["avatar_url"])
+    async def get_team(self, org_name: str, team_name: str) -> OrganizationTeam:
+        url = f"https://api.github.com/orgs/{org_name}/teams/{team_name}"
+        return await self.fetch(url)
+
+
+class GitHubCog(commands.Cog):
+    def __init__(self, bot: MILBot):
+        self.bot = bot
+        self.github = GitHub(
+            auth_token=GITHUB_TOKEN,
+            bot=bot,
+        )
+        self.mil_repo = self.github.get_repo("uf-mil/mil")
+
+    async def get_commit(self, commit_hash: str) -> discord.Embed | None:
+        logging.info(f"Getting commit info for hash {commit_hash}...")
+        try:
+            commits = await self.github.search_commits(commit_hash)
+        except aiohttp.ClientResponseError as e:
+            if e.status == 422:
+                return None
+            else:
+                raise
+
+        commits = commits["items"]
+        if commits:
+            commit = commits[0]
+            org_name = commit["repository"]["owner"]["login"]
+            repo_name = commit["repository"]["name"]
+            branches_response = await self.github.get_branches_for_commit(
+                f"{org_name}/{repo_name}",
+                commit_hash,
+            )
+            branches = [branch["name"] for branch in branches_response]
+
+            # URL to get status and checks for the commit
+            checks_response = await self.github.get_checks(
+                f"{org_name}/{repo_name}",
+                commit_hash,
+            )
+
+            embed = discord.Embed(
+                title=commit["sha"],
+                color=discord.Color.green(),
+                url=commit["html_url"],
+            )
+            embed.set_thumbnail(url=commit["repository"]["owner"]["avatar_url"])
+            if commit["author"]:
                 embed.set_author(
                     name=commit["author"]["login"],
                     url=commit["author"]["html_url"],
                     icon_url=commit["author"]["avatar_url"],
                 )
-                embed.add_field(
-                    name="Repository",
-                    value=f"[`{commit['repository']['full_name']}`]({commit['repository']['html_url']})",
-                    inline=True,
-                )
-                iso_date = datetime.datetime.fromisoformat(
-                    commit["commit"]["author"]["date"],
-                )
-                embed.add_field(
-                    name="Committed at",
-                    value=f"{discord.utils.format_dt(iso_date, style='F')} ({discord.utils.format_dt(iso_date, style='R')})",
-                    inline=True,
-                )
-                embed.add_field(
-                    name="Message",
-                    value=commit["commit"]["message"][:1024],
-                    inline=False,
-                )
-                embed.add_field(
-                    name="Branches",
-                    value=", ".join(
-                        f"[`{branch}`]({commit['repository']['html_url']}/tree/{branch})"
-                        for branch in branches
-                    ),
-                    inline=False,
-                )
-                embed.add_field(
-                    name="Checks",
-                    value="\n".join(
-                        f"{'✅' if check['conclusion'] else '❌'} [{check['name']}]({check['html_url']})"
-                        for check in checks_response.json()["check_runs"]
-                    ),
-                    inline=False,
-                )
-                return embed
+            embed.add_field(
+                name="Repository",
+                value=f"[`{commit['repository']['full_name']}`]({commit['repository']['html_url']})",
+                inline=True,
+            )
+            iso_date = datetime.datetime.fromisoformat(
+                commit["commit"]["author"]["date"],
+            )
+            embed.add_field(
+                name="Committed at",
+                value=f"{discord.utils.format_dt(iso_date, style='F')} ({discord.utils.format_dt(iso_date, style='R')})",
+                inline=True,
+            )
+            embed.add_field(
+                name="Message",
+                value=commit["commit"]["message"][:1024],
+                inline=False,
+            )
+            embed.add_field(
+                name="Branches",
+                value=", ".join(
+                    f"[`{branch}`]({commit['repository']['html_url']}/tree/{branch})"
+                    for branch in branches
+                ),
+                inline=False,
+            )
+            embed.add_field(
+                name="Checks",
+                value="\n".join(
+                    f"{'✅' if check['conclusion'] else '❌'} [{check['name']}]({check['html_url']})"
+                    for check in checks_response["check_runs"]
+                ),
+                inline=False,
+            )
+            return embed
 
         return None
 
     def get_issue_or_pull(self, issue: Issue):
         res = discord.Embed(
-            title=f"{issue.title} (#{issue.number})",
+            title=f"{issue['title']} (#{issue['number']})",
             color=discord.Color.green(),
-            url=issue.html_url,
-            description=f"Details of this issue/pull request can be found [here]({issue.html_url}).",
+            url=issue["html_url"],
+            description=f"Details of this issue/pull request can be found [here]({issue['html_url']}).",
         )
-        res.set_author(
-            name=issue.user.login,
-            url=issue.user.html_url,
-            icon_url=issue.user.avatar_url,
-        )
-        res.set_thumbnail(url=issue.user.avatar_url)
+        if issue["user"]:
+            res.set_author(
+                name=issue["user"]["login"],
+                url=issue["user"]["html_url"],
+                icon_url=issue["user"]["avatar_url"],
+            )
+            res.set_thumbnail(url=issue["user"]["avatar_url"])
         res.add_field(
             name="Repository",
-            value=f"[`{issue.repository.full_name}`]({issue.repository.html_url})",
+            value=f"[`uf-mil/mil`]({issue['repository_url']})",
             inline=True,
         )
-        iso_date = issue.created_at
+        iso_date = issue["created_at"]
+        iso_date = datetime.datetime.fromisoformat(iso_date)
         res.add_field(
             name="Created at",
             value=f"{discord.utils.format_dt(iso_date, style='F')}\n({discord.utils.format_dt(iso_date, style='R')})",
@@ -141,26 +227,26 @@ class GitHub(commands.Cog):
         )
         res.add_field(
             name="State",
-            value=issue.state,
+            value=issue["state"],
             inline=True,
         )
         res.add_field(
             name="Labels",
-            value=", ".join(f"`{label.name}`" for label in issue.labels),
+            value=", ".join(f"`{label['name']}`" for label in issue["labels"]),
             inline=True,
         )
         res.add_field(
             name="Assignees",
             value=", ".join(
-                f"[`{assignee.login}`]({assignee.html_url})"
-                for assignee in issue.assignees
+                f"[`{assignee['login']}`]({assignee['html_url']})"
+                for assignee in issue["assignees"]
             ),
             inline=True,
         )
         res.add_field(
             name="Milestone",
-            value=f"[`{issue.milestone.title}`]({issue.milestone.url})"
-            if issue.milestone
+            value=f"[`{issue['milestone']['title']}`]({issue['milestone']['html_url']})"
+            if issue["milestone"]
             else "None",
             inline=True,
         )
@@ -178,7 +264,7 @@ class GitHub(commands.Cog):
             re.IGNORECASE | re.MULTILINE,
         )
         if hashes:
-            embeds = [self.get_commit(commit_hash) for commit_hash in hashes]
+            embeds = [await self.get_commit(commit_hash) for commit_hash in hashes]
             if any(not e for e in embeds):
                 pass
             else:
@@ -197,7 +283,7 @@ class GitHub(commands.Cog):
         )
         if matches:
             for match in matches:
-                issue = self.mil_repo.get_issue(int(match))
+                issue = await self.github.get_issue("uf-mil/mil", int(match))
                 await message.reply(embed=self.get_issue_or_pull(issue))
 
     @app_commands.command()
@@ -217,37 +303,28 @@ class GitHub(commands.Cog):
             org_name: The name of the organization to invite the user to.
         """
         # Use the Github class object to send an invite to the user
-        if org_name == "uf-mil":
-            org = self.github.get_organization("uf-mil")
-        elif org_name == "uf-mil-electrical":
-            org = self.github.get_organization("uf-mil-electrical")
-        else:
+        if org_name not in ["uf-mil", "uf-mil-electrical"]:
             await interaction.response.send_message("Invalid organization name.")
             return
 
         # Ensure that the specified username is actually a GitHub user, and get
         # their user object
         try:
-            user = self.github.get_user(username)
-        except github.GithubException:
-            await interaction.response.send_message(
-                f"Failed to find user with username {username}.",
-            )
-            return
-
-        if isinstance(user, AuthenticatedUser.AuthenticatedUser):
-            await interaction.response.send_message(
-                "Uh oh! I can't add a user who is already signed in.",
-            )
-            return
+            user = await self.github.get_user(username)
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                await interaction.response.send_message(
+                    f"Failed to find user with username {username}.",
+                )
+            raise e
 
         try:
             # If the org is uf-mil, invite to the "Developers" team
             if org_name == "uf-mil":
-                team = org.get_team_by_slug("developers")
-                org.invite_user(user, teams=[team])
+                team = await self.github.get_team(org_name, "developers")
+                await self.github.invite_user_to_org(user["id"], org_name, team["id"])
             else:
-                org.invite_user(user)
+                await self.github.invite_user_to_org(user["id"], org_name)
             await interaction.response.send_message(
                 f"Successfully invited {username} to {org_name}.",
             )
@@ -259,4 +336,4 @@ class GitHub(commands.Cog):
 
 
 async def setup(bot: MILBot):
-    await bot.add_cog(GitHub(bot))
+    await bot.add_cog(GitHubCog(bot))

--- a/src/github_types.py
+++ b/src/github_types.py
@@ -319,27 +319,6 @@ class Commit(TypedDict):
     comment_count: int
 
 
-class User(TypedDict):
-    login: str
-    id: int
-    node_id: str
-    avatar_url: str
-    gravatar_id: str
-    url: str
-    html_url: str
-    followers_url: str
-    following_url: str
-    gists_url: str
-    starred_url: str
-    subscriptions_url: str
-    organizations_url: str
-    repos_url: str
-    events_url: str
-    received_events_url: str
-    type: str
-    site_admin: bool
-
-
 class ParentCommit(TypedDict):
     url: str
     html_url: str

--- a/src/github_types.py
+++ b/src/github_types.py
@@ -1,0 +1,388 @@
+from typing import TypedDict
+
+
+class User(TypedDict):
+    login: str
+    id: int
+    node_id: str
+    avatar_url: str
+    gravatar_id: str
+    url: str
+    html_url: str
+    followers_url: str
+    following_url: str
+    gists_url: str
+    starred_url: str
+    subscriptions_url: str
+    organizations_url: str
+    repos_url: str
+    events_url: str
+    received_events_url: str
+    type: str
+    site_admin: bool
+    name: str | None
+    company: str | None
+    blog: str | None
+    location: str | None
+    email: str | None
+    hireable: bool | None
+    bio: str | None
+    twitter_username: str | None
+    public_repos: int
+    public_gists: int
+    followers: int
+    following: int
+    created_at: str
+    updated_at: str
+
+
+class Organization(TypedDict):
+    login: str
+    id: int
+    node_id: str
+    url: str
+    repos_url: str
+    events_url: str
+    hooks_url: str
+    issues_url: str
+    members_url: str
+    public_members_url: str
+    avatar_url: str
+    description: str
+    name: str
+    company: str
+    blog: str
+    location: str
+    email: str
+    is_verified: bool
+    has_organization_projects: bool
+    has_repository_projects: bool
+    public_repos: int
+    public_gists: int
+    followers: int
+    following: int
+    html_url: str
+    created_at: str
+    updated_at: str
+    type: str
+
+
+class OrganizationTeam(TypedDict):
+    id: int
+    node_id: str
+    url: str
+    html_url: str
+    name: str
+    slug: str
+    description: str
+    privacy: str
+    notification_setting: str
+    permission: str
+    members_url: str
+    repositories_url: str
+    parent: None
+    members_count: int
+    repos_count: int
+    created_at: str
+    updated_at: str
+    organization: Organization
+
+
+class Label(TypedDict):
+    id: int
+    node_id: str
+    url: str
+    name: str
+    description: str
+    color: str
+    default: bool
+
+
+class Milestone(TypedDict):
+    url: str
+    html_url: str
+    labels_url: str
+    id: int
+    node_id: str
+    number: int
+    state: str
+    title: str
+    description: str
+    creator: User
+    open_issues: int
+    closed_issues: int
+    created_at: str
+    updated_at: str
+    closed_at: str | None
+    due_on: str
+
+
+class PullRequest(TypedDict):
+    url: str
+    html_url: str
+    diff_url: str
+    patch_url: str
+
+
+class RepositoryPermissions(TypedDict):
+    admin: bool
+    push: bool
+    pull: bool
+
+
+class RepositorySecurityAndAnalysisItem(TypedDict):
+    status: str
+
+
+class RepositorySecurityAndAnalysis(TypedDict):
+    advanced_security: RepositorySecurityAndAnalysisItem
+    secret_scanning: RepositorySecurityAndAnalysisItem
+    secret_scanning_push_protection: RepositorySecurityAndAnalysisItem
+
+
+class Repository(TypedDict):
+    id: int
+    node_id: str
+    name: str
+    full_name: str
+    owner: User
+    private: bool
+    html_url: str
+    description: str | None
+    fork: bool
+    url: str
+    archive_url: str
+    assignees_url: str
+    blobs_url: str
+    branches_url: str
+    collaborators_url: str
+    comments_url: str
+    commits_url: str
+    compare_url: str
+    contents_url: str
+    contributors_url: str
+    deployments_url: str
+    downloads_url: str
+    events_url: str
+    forks_url: str
+    git_commits_url: str
+    git_refs_url: str
+    git_tags_url: str
+    git_url: str
+    issue_comment_url: str
+    issue_events_url: str
+    issues_url: str
+    keys_url: str
+    labels_url: str
+    languages_url: str
+    merges_url: str
+    milestones_url: str
+    notifications_url: str
+    pulls_url: str
+    releases_url: str
+    ssh_url: str
+    stargazers_url: str
+    statuses_url: str
+    subscribers_url: str
+    subscription_url: str
+    tags_url: str
+    teams_url: str
+    trees_url: str
+    clone_url: str
+    mirror_url: str
+    hooks_url: str
+    svn_url: str
+    homepage: str | None
+    language: str | None
+    forks_count: int
+    stargazers_count: int
+    watchers_count: int
+    size: int
+    default_branch: str
+    open_issues_count: int
+    is_template: bool
+    topics: list[str]
+    has_issues: bool
+    has_projects: bool
+    has_wiki: bool
+    has_pages: bool
+    has_downloads: bool
+    has_discussions: bool
+    archived: bool
+    disabled: bool
+    visibility: str
+    pushed_at: str
+    created_at: str
+    updated_at: str
+    permissions: RepositoryPermissions
+    security_and_analysis: RepositorySecurityAndAnalysis
+
+
+class Issue(TypedDict):
+    id: int
+    node_id: str
+    url: str
+    repository_url: str
+    labels_url: str
+    comments_url: str
+    events_url: str
+    html_url: str
+    number: int
+    state: str
+    title: str
+    body: str
+    user: User
+    labels: list[Label]
+    assignee: User
+    assignees: list[User]
+    milestone: Milestone
+    locked: bool
+    active_lock_reason: str
+    comments: int
+    pull_request: PullRequest
+    closed_at: str | None
+    created_at: str
+    updated_at: str
+    closed_by: User | None
+    author_association: str
+    state_reason: str | None
+
+
+class CheckRunOutput(TypedDict):
+    title: str
+    summary: str
+    text: str
+    annotations_count: int
+    annotations_url: str
+
+
+class CheckSuite(TypedDict):
+    id: int
+
+
+class App(TypedDict):
+    id: int
+    slug: str
+    node_id: str
+    owner: User
+    name: str
+    description: str
+    external_url: str
+    html_url: str
+    created_at: str
+    updated_at: str
+    permissions: dict
+    events: list[str]
+
+
+class CheckRun(TypedDict):
+    id: int
+    head_sha: str
+    node_id: str
+    external_id: str
+    url: str
+    html_url: str
+    details_url: str
+    status: str
+    conclusion: str
+    started_at: str
+    completed_at: str
+    output: CheckRunOutput
+    name: str
+    check_suite: CheckSuite
+    app: App
+    pull_requests: list[PullRequest]
+
+
+class CheckRunsData(TypedDict):
+    total_count: int
+    check_runs: list[CheckRun]
+
+
+class CommitAuthor(TypedDict):
+    date: str
+    name: str
+    email: str
+
+
+class Tree(TypedDict):
+    url: str
+    sha: str
+
+
+class Commit(TypedDict):
+    url: str
+    author: CommitAuthor
+    committer: CommitAuthor
+    message: str
+    tree: Tree
+    comment_count: int
+
+
+class User(TypedDict):
+    login: str
+    id: int
+    node_id: str
+    avatar_url: str
+    gravatar_id: str
+    url: str
+    html_url: str
+    followers_url: str
+    following_url: str
+    gists_url: str
+    starred_url: str
+    subscriptions_url: str
+    organizations_url: str
+    repos_url: str
+    events_url: str
+    received_events_url: str
+    type: str
+    site_admin: bool
+
+
+class ParentCommit(TypedDict):
+    url: str
+    html_url: str
+    sha: str
+
+
+class GitHubCommit(TypedDict):
+    url: str
+    sha: str
+    html_url: str
+    comments_url: str
+    commit: Commit
+    author: User | None  # This can be None if the user is not on GitHub anymore
+    committer: User | None  # This can also be None
+    parents: list[ParentCommit]
+    repository: Repository
+
+
+class CommitSearchResults(TypedDict):
+    total_count: int
+    incomplete_results: bool
+    items: list[GitHubCommit]
+
+
+class CommitPointer(TypedDict):
+    sha: str
+    url: str
+
+
+class Branch(TypedDict):
+    name: str
+    commit: CommitPointer
+    protected: bool
+
+
+class Invitation(TypedDict):
+    id: int
+    login: str
+    node_id: str
+    email: str | None
+    role: str
+    created_at: str
+    inviter: User
+    team_count: int
+    invitation_teams_url: str
+    invitation_source: str


### PR DESCRIPTION
The GitHub code is now async, meaning that it will not block other requests. This:

* Allows multiple interactions (button clicks, command calls, commit lookups, etc.) to occur at once without the GitHub-related interactions blocking other interactions
* Speeds up GitHub calls (roughly 1.9s to 1.1s for commit lookups and 1.1s to 0.7s for issue lookups)
* Reduces the number of calls sent to GitHub
* Introduces complete typing for all GitHub functionality without adding any additional dependencies (except `aiohttp`)