### PR TITLE
Disable reports button when not active

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -127,6 +127,7 @@ class MILBot(commands.Bot):
         if not self.change_status.is_running():
             self.change_status.start()
         await self.fetch_vars()
+        await self.reports_cog.update_report_channel.run_immediately()
 
     async def close(self):
         await self.session.close()


### PR DESCRIPTION
This disables the reports button when not active/relevant.

Example (shown between semesters):
![ss 2024-03-11 at 00 06 59@2x](https://github.com/uf-mil/discord-bot/assets/52760912/7a4b68ae-83a7-48a0-af46-9b4d8035324e)

Normal operation, for reference:
![ss 2024-03-11 at 00 07 19@2x](https://github.com/uf-mil/discord-bot/assets/52760912/6fd67c3b-e4e4-4e9c-ba3d-ceafeac43819)

