### PR TITLE
Add member services

### DIFF
--- a/src/anonymous.py
+++ b/src/anonymous.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import discord
+
+from .email import send_email
+from .views import MILBotModal, MILBotView
+
+if TYPE_CHECKING:
+    from .bot import MILBot
+
+
+IntendedTargets = Literal["schwartz", "operations", "leaders"]
+
+
+class AnonymousReportModal(MILBotModal):
+
+    report = discord.ui.TextInput(
+        label="Report",
+        placeholder="Enter your report here",
+        style=discord.TextStyle.long,
+        max_length=2000,
+    )
+
+    def __init__(self, bot: MILBot, target: IntendedTargets):
+        self.bot = bot
+        self.target = target
+        super().__init__(title="Submit an Anonymous Report")
+
+    async def on_submit(self, interaction: discord.Interaction):
+        embed = discord.Embed(
+            title="New Anonymous Report",
+            color=discord.Color.light_gray(),
+            description=self.report.value,
+        )
+        embed.set_footer(text="Submitted by an anonymous user")
+        if self.target == "schwartz":
+            html = f"""A new anonymous report has been submitted. The report is as follows:
+
+            <blockquote>{self.report.value}</blockquote>
+
+            Replies to this email will not be received. Please address any concerns with the appropriate leadership team."""
+            text = f"""A new anonymous report has been submitted. The report is as follows:
+
+            {self.report.value}
+
+            Replies to this email will not be received. Please address any concerns with the appropriate leadership team."""
+            await send_email(
+                "cbrown14@ufl.edu",
+                "New Anonymous Report Received",
+                html,
+                text,
+            )
+        elif self.target == "operations":
+            await self.bot.operations_leaders_channel.send(embed=embed)
+        elif self.target == "leaders":
+            await self.bot.leaders_channel.send(embed=embed)
+        await interaction.response.send_message(
+            "Your report has been submitted. Your input is invaluable, and we are committed to making MIL a better place for everyone. Thank you for helping us improve.",
+            embed=embed,
+            ephemeral=True,
+        )
+
+
+class AnonymousTargetSelect(discord.ui.Select):
+    def __init__(self, bot: MILBot):
+        self.bot = bot
+        options = [
+            discord.SelectOption(label="Dr. Schwartz", emoji="👨‍🏫", value="schwartz"),
+            discord.SelectOption(
+                label="Operations Leadership",
+                emoji="👷",
+                value="operations",
+            ),
+            discord.SelectOption(label="Leaders", emoji="👑", value="leaders"),
+        ]
+        super().__init__(
+            placeholder="Select the target of your report",
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        target = self.values[0]
+        await interaction.response.send_modal(AnonymousReportModal(self.bot, target))  # type: ignore
+
+
+class AnonymousReportView(MILBotView):
+    def __init__(self, bot: MILBot):
+        self.bot = bot
+        super().__init__(timeout=None)
+
+    @discord.ui.button(
+        label="Submit an anonymous report",
+        style=discord.ButtonStyle.red,
+        custom_id="anonymous_report:submit",
+    )
+    async def submit_anonymous_report(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ):
+        view = MILBotView()
+        view.add_item(AnonymousTargetSelect(self.bot))
+        await interaction.response.send_message(
+            "Select the target of your report.",
+            view=view,
+            ephemeral=True,
+        )

--- a/src/bot.py
+++ b/src/bot.py
@@ -360,6 +360,13 @@ class MILBot(commands.Bot):
         assert isinstance(alumni_role, discord.Role)
         self.alumni_role = alumni_role
 
+        away_role = discord.utils.get(
+            self.active_guild.roles,
+            name="Away from MIL",
+        )
+        assert isinstance(away_role, discord.Role)
+        self.away_role = away_role
+
         reports_cog = self.get_cog("ReportsCog")
         if not reports_cog:
             raise ResourceNotFound("Reports cog not found.")

--- a/src/bot.py
+++ b/src/bot.py
@@ -31,7 +31,7 @@ from .env import (
     GUILD_ID,
 )
 from .exceptions import MILBotErrorHandler, ResourceNotFound
-from .github import GitHub
+from .github import GitHub, GitHubInviteView
 from .projects import SoftwareProjectsView
 from .reports import ReportsCog, ReportsView
 from .roles import MechanicalRolesView, SummerRolesView, TeamRolesView
@@ -233,6 +233,7 @@ class MILBot(commands.Bot):
         self.add_view(SummerRolesView(self))
         self.add_view(StartEmailVerificationView(self))
         self.add_view(AnonymousReportView(self))
+        self.add_view(GitHubInviteView(self))
 
         agcm = gspread_asyncio.AsyncioGspreadClientManager(get_creds)
         self.agc = await agcm.authorize()

--- a/src/bot.py
+++ b/src/bot.py
@@ -17,6 +17,7 @@ from google.auth import crypt
 from google.oauth2.service_account import Credentials
 from rich.logging import RichHandler
 
+from .anonymous import AnonymousReportView
 from .calendar import CalendarView
 from .constants import Team
 from .env import (
@@ -88,10 +89,11 @@ class MILBot(commands.Bot):
     leaders_channel: discord.TextChannel
     leave_channel: discord.TextChannel
     general_channel: discord.TextChannel
-    reports_channel: discord.TextChannel
+    member_services_channel: discord.TextChannel
     errors_channel: discord.TextChannel
     software_projects_channel: discord.TextChannel
     software_category_channel: discord.CategoryChannel
+    operations_leaders_channel: discord.TextChannel
 
     # Emojis
     loading_emoji: str
@@ -230,6 +232,7 @@ class MILBot(commands.Bot):
         self.add_view(TestingSignUpView(self, ""))
         self.add_view(SummerRolesView(self))
         self.add_view(StartEmailVerificationView(self))
+        self.add_view(AnonymousReportView(self))
 
         agcm = gspread_asyncio.AsyncioGspreadClientManager(get_creds)
         self.agc = await agcm.authorize()
@@ -258,12 +261,12 @@ class MILBot(commands.Bot):
         assert isinstance(general_channel, discord.TextChannel)
         self.general_channel = general_channel
 
-        reports_channel = discord.utils.get(
+        member_services_channel = discord.utils.get(
             self.active_guild.text_channels,
-            name="reports",
+            name="member-services",
         )
-        assert isinstance(reports_channel, discord.TextChannel)
-        self.reports_channel = reports_channel
+        assert isinstance(member_services_channel, discord.TextChannel)
+        self.member_services_channel = member_services_channel
 
         leaders_channel = discord.utils.get(
             self.active_guild.text_channels,
@@ -271,6 +274,13 @@ class MILBot(commands.Bot):
         )
         assert isinstance(leaders_channel, discord.TextChannel)
         self.leaders_channel = leaders_channel
+
+        operations_leaders_channel = discord.utils.get(
+            self.active_guild.text_channels,
+            name="operations-leadership",
+        )
+        assert isinstance(operations_leaders_channel, discord.TextChannel)
+        self.operations_leaders_channel = operations_leaders_channel
 
         errors_channel = discord.utils.get(
             self.active_guild.text_channels,

--- a/src/leaders.py
+++ b/src/leaders.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import discord
 from discord.ext import commands
 
+from .anonymous import AnonymousReportView
 from .env import LEADERS_MEETING_NOTES_URL, LEADERS_MEETING_URL
 from .tasks import run_on_weekday
 from .utils import is_active
@@ -137,6 +138,23 @@ class Leaders(commands.Cog):
             embed=embed,
             view=StartEmailVerificationView(self.bot),
         )
+
+    @commands.command()
+    @commands.is_owner()
+    async def prepanonymous(self, ctx: commands.Context):
+        embed = discord.Embed(
+            title="File an Anonymous Report",
+            description="""Your voice matters to us. If you have feedback or concerns about your experience at MIL, please feel comfortable using our anonymous reporting tool. By clicking the button below, you can file a report without revealing your identity, ensuring your privacy and safety.
+
+            We treat all submissions with the utmost seriousness and respect. When filing your report, you have the option to select who will receive and review this information. To help us address your concerns most effectively, please provide as much detail as possible in your submission.""",
+            color=discord.Color.from_rgb(249, 141, 139),
+        )
+        view = AnonymousReportView(self.bot)
+        await ctx.send(
+            embed=embed,
+            view=view,
+        )
+        await ctx.message.delete()
 
 
 async def setup(bot: MILBot):

--- a/src/leaders.py
+++ b/src/leaders.py
@@ -14,6 +14,7 @@ from discord.ext import commands
 
 from .anonymous import AnonymousReportView
 from .env import LEADERS_MEETING_NOTES_URL, LEADERS_MEETING_URL
+from .github import GitHubInviteView
 from .tasks import run_on_weekday
 from .utils import is_active
 from .verification import StartEmailVerificationView
@@ -224,6 +225,18 @@ class Leaders(commands.Cog):
             You can use the button below to toggle your away status on and off. Enjoy your break!""",
             color=self.bot.away_role.color,
         )
+        await ctx.send(embed=embed, view=view)
+        await ctx.message.delete()
+
+    @commands.command()
+    @commands.is_owner()
+    async def prepgithub(self, ctx: commands.Context):
+        embed = discord.Embed(
+            title="Invite Members to GitHub",
+            description="Use the following buttons to invite members to the software or electrical GitHub organizations. Please ensure that the member has a GitHub account before inviting them.",
+            color=discord.Color.light_gray(),
+        )
+        view = GitHubInviteView(self.bot)
         await ctx.send(embed=embed, view=view)
         await ctx.message.delete()
 

--- a/src/reports.py
+++ b/src/reports.py
@@ -252,7 +252,7 @@ class ReportsCog(commands.Cog):
     async def post_reminder(self):
         general_channel = self.bot.general_channel
         return await general_channel.send(
-            f"{self.bot.egn4912_role.mention}\nHey everyone! Friendly reminder to submit your weekly progress reports by **Sunday night at 11:59pm**. You can submit your reports in the {self.bot.reports_channel.mention} channel. If you have any questions, please contact your leader. Thank you!",
+            f"{self.bot.egn4912_role.mention}\nHey everyone! Friendly reminder to submit your weekly progress reports by **Sunday night at 11:59pm**. You can submit your reports in the {self.bot.member_services_channel.mention} channel. If you have any questions, please contact your leader. Thank you!",
         )
 
     async def safe_col_values(
@@ -303,7 +303,7 @@ class ReportsCog(commands.Cog):
             if student.member and not student.report:
                 try:
                     await student.member.send(
-                        f"Hey **{student.first_name}**! It's your friendly uf-mil-bot here. I noticed you haven't submitted your weekly MIL report yet. Please submit it in the {self.bot.reports_channel.mention} channel by {discord.utils.format_dt(deadline_tonight, 't')} tonight. Thank you!",
+                        f"Hey **{student.first_name}**! It's your friendly uf-mil-bot here. I noticed you haven't submitted your weekly MIL report yet. Please submit it in the {self.bot.member_services_channel.mention} channel by {discord.utils.format_dt(deadline_tonight, 't')} tonight. Thank you!",
                     )
                     logger.info(f"Sent individual report reminder to {student.member}.")
                 except discord.Forbidden:
@@ -358,7 +358,10 @@ class ReportsCog(commands.Cog):
     async def update_report_channel(self):
         channel_history = [
             m
-            async for m in self.bot.reports_channel.history(limit=1, oldest_first=True)
+            async for m in self.bot.member_services_channel.history(
+                limit=1,
+                oldest_first=True,
+            )
         ]
         if not channel_history:
             return


### PR DESCRIPTION
This PR:
* Renames `#reports` to `#member-services` to serve as a channel where various member services can be accessed.
* Embeds the anonymous complaint form inside Discord for easier access
* Provides the ability for leaders to mark themselves as Away from MIL
    * Any member who mentions an away leader will be notified that the leader is away and may be unable to respond
* Removes `#admin-bot-commands` in favor of `#leader-services`.
* Moves the GitHub invitation functionality into a view